### PR TITLE
added a search field and toggle preview to UI

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -25,7 +25,7 @@ preview {
   display: flex;
   flex-direction: row;
   width: 100%;
-  height: 90vh;
+  height: 88vh;
 }
 
 .split {
@@ -45,4 +45,14 @@ preview {
 /* Control the right side */
 .right {
   right: 0;
+}
+
+.hidden {
+  display: none;
+}
+
+.no-preview {
+  width: 75%;
+  justify-self: center;
+  margin: auto !important;
 }

--- a/client/src/components/Drawer.tsx
+++ b/client/src/components/Drawer.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Dispatch } from 'react'
 import clsx from 'clsx'
 import {
   alpha,
@@ -11,6 +11,7 @@ import Drawer from '@material-ui/core/Drawer'
 import AppBar from '@material-ui/core/AppBar'
 import Toolbar from '@material-ui/core/Toolbar'
 import List from '@material-ui/core/List'
+import Button from '@material-ui/core/Button'
 import CssBaseline from '@material-ui/core/CssBaseline'
 import Typography from '@material-ui/core/Typography'
 import Divider from '@material-ui/core/Divider'
@@ -27,6 +28,7 @@ import ListItemText from '@material-ui/core/ListItemText'
 import InboxIcon from '@material-ui/icons/MoveToInbox'
 import MailIcon from '@material-ui/icons/Mail'
 import { fakeNotes } from '../mock/fakeNotes'
+import { SetStateAction } from 'react'
 
 const drawerWidth = 380
 
@@ -135,7 +137,9 @@ const useStyles = makeStyles((theme: Theme) =>
 )
 
 interface Props {
-  children: React.ReactNode
+  children: React.ReactElement<any>
+  preview: boolean
+  handlePreview: Dispatch<SetStateAction<boolean>>
 }
 
 export default function NotesDrawer(props: Props): JSX.Element {
@@ -188,6 +192,16 @@ export default function NotesDrawer(props: Props): JSX.Element {
               inputProps={{ 'aria-label': 'search' }}
             />
           </div>
+          <Button
+            variant="contained"
+            color="secondary"
+            disableElevation
+            onClick={() => {
+              props.handlePreview(!props.preview)
+            }}
+          >
+            Toggle Preview
+          </Button>
         </Toolbar>
       </AppBar>
       <Drawer

--- a/client/src/components/Editable.tsx
+++ b/client/src/components/Editable.tsx
@@ -1,17 +1,23 @@
-import React from 'react';
+import React from 'react'
+import clsx from 'clsx'
 interface Props {
-  handleChange: (event: string) => void;
-  value: string;
+  handleChange: (event: string) => void
+  value: string
+  preview: boolean
 }
 
-export const Editable: React.FC<Props> = ({ handleChange, value }: Props) => {
-
+export const Editable: React.FC<Props> = ({
+  handleChange,
+  value,
+  preview,
+}: Props) => {
   return (
-      <textarea
-        value={value}
-        onChange={(event) => {
-          handleChange(event.target.value);
-        }}
-      />
-  );
-};
+    <textarea
+      className={clsx({ ['no-preview']: !preview })}
+      value={value}
+      onChange={(event) => {
+        handleChange(event.target.value)
+      }}
+    />
+  )
+}

--- a/client/src/components/Preview.tsx
+++ b/client/src/components/Preview.tsx
@@ -1,18 +1,25 @@
 import React from 'react'
 import marked from 'marked'
+import clsx from 'clsx'
 
 marked.setOptions({
-    breaks: true,
+  breaks: true,
 })
 
 interface Props {
-    text: string
+  text: string
+  preview: boolean
 }
 
-export const Preview: React.FC<Props> = ({ text }: Props) => {
-    const toHTML = () => {
-        return { __html: marked(text) }
-    }
+export const Preview: React.FC<Props> = ({ text, preview }: Props) => {
+  const toHTML = () => {
+    return { __html: marked(text) }
+  }
 
-    return <div dangerouslySetInnerHTML={toHTML()} className="preview" />
+  return (
+    <div
+      dangerouslySetInnerHTML={preview ? toHTML() : undefined}
+      className={clsx('preview', { ['hidden']: !preview })}
+    />
+  )
 }

--- a/client/src/components/StateContainer.tsx
+++ b/client/src/components/StateContainer.tsx
@@ -8,12 +8,18 @@ export const StateContainer: React.FC = () => {
     '# Hello World \n## Write in Markdown, see preview\n**bold** _italic_ \nTry typing markdown here'
   )
 
+  const [preview, setPreview] = useState(true)
+
   return (
     <>
-      <NotesDrawer>
+      <NotesDrawer preview={preview} handlePreview={setPreview.bind(this)}>
         <div className="flex-container">
-          <Editable value={value} handleChange={setValue.bind(this)} />
-          <Preview text={value} />
+          <Editable
+            value={value}
+            handleChange={setValue.bind(this)}
+            preview={preview}
+          />
+          <Preview text={value} preview={preview} />
         </div>
       </NotesDrawer>
     </>


### PR DESCRIPTION
## Description of Issue
Added an input for searching in the top toolbar, and a button to toggle preview during editing

![toggle preview](https://user-images.githubusercontent.com/62415298/126379999-e6607dbf-bf12-4c50-8873-5048312cabd0.gif)

## Testing
*Have you tested this change? On what devices?*
Chrome in Windows

### To Test
- Type anything in the Search box, it should allow text entry
- Use the toggle preview button to turn preview on/off

## Time Spent
- *How long did you estimate this task would take?* 3 hours
- *How long did it take you to work on this issue?* 3 hours

## Checklist
- [x] Did you remove all console logs?
- [x] Did you assign reviewers? 
